### PR TITLE
Correctly add duty officers to recipient lists

### DIFF
--- a/cabot_alert_email/__init__.py
+++ b/cabot_alert_email/__init__.py
@@ -1,2 +1,1 @@
-__all__ = ["models",]
-
+__all__ = ["models", ]

--- a/cabot_alert_email/models.py
+++ b/cabot_alert_email/models.py
@@ -2,13 +2,10 @@ from os import environ as env
 
 from django.conf import settings
 from django.core.mail import send_mail
-from django.core.urlresolvers import reverse
 from django.template import Context, Template
 
 from cabot.cabotapp.alert import AlertPlugin
 
-import requests
-import logging
 
 email_template = """Service {{ service.name }} {{ scheme }}://{{ host }}{% url 'service' pk=service.id %} {% if service.overall_status != service.PASSING_STATUS %}alerting with status: {{ service.overall_status }}{% else %}is back to normal{% endif %}.
 {% if service.overall_status != service.PASSING_STATUS %}
@@ -20,6 +17,7 @@ Passing checks:{% for check in service.all_passing_checks %}
 {% endif %}
 {% endif %}
 """
+
 
 class EmailAlert(AlertPlugin):
     name = "Email"

--- a/cabot_alert_email/models.py
+++ b/cabot_alert_email/models.py
@@ -34,7 +34,7 @@ class EmailAlert(AlertPlugin):
         })
         if service.overall_status != service.PASSING_STATUS:
             if service.overall_status == service.CRITICAL_STATUS:
-                emails += [u.email for u in users if u.email]
+                emails += [u.email for u in duty_officers if u.email]
             subject = '%s status for service: %s' % (
                 service.overall_status, service.name)
         else:

--- a/cabot_alert_email/tests/test_email.py
+++ b/cabot_alert_email/tests/test_email.py
@@ -1,9 +1,10 @@
-from cabot.cabotapp.tests.tests_basic import LocalTestCase
-from mock import Mock, patch
+from mock import patch
 
-from cabot.cabotapp.models import UserProfile, Service
-from cabot_alert_email import models
 from cabot.cabotapp.alert import update_alert_plugins
+from cabot.cabotapp.models import Service, UserProfile
+from cabot.cabotapp.tests.tests_basic import LocalTestCase
+
+from cabot_alert_email import models
 
 
 class TestEmailAlerts(LocalTestCase):
@@ -37,7 +38,12 @@ class TestEmailAlerts(LocalTestCase):
         self.service.old_overall_status = Service.ERROR_STATUS
         self.service.save()
         self.service.alert()
-        fake_send_mail.assert_called_with(message=u'Service Service http://localhost/service/1/ is back to normal.\n\n', subject='Service back to normal: Service', recipient_list=[u'test@userprofile.co.uk'], from_email='Cabot <cabot@example.com>')
+        fake_send_mail.assert_called_with(
+            message=u'Service Service http://localhost/service/1/ is back to normal.\n\n',
+            subject='Service back to normal: Service',
+            recipient_list=[u'test@userprofile.co.uk'],
+            from_email='Cabot <cabot@example.com>'
+        )
 
     @patch('cabot_alert_email.models.send_mail')
     def test_failure_alert(self, fake_send_mail):
@@ -46,5 +52,9 @@ class TestEmailAlerts(LocalTestCase):
         self.service.old_overall_status = Service.PASSING_STATUS
         self.service.save()
         self.service.alert()
-        fake_send_mail.assert_called_with(message=u'Service Service http://localhost/service/1/ alerting with status: failing.\n\nCHECKS FAILING:\n\nPassing checks:\n  PASSING - Graphite Check - Type: Metric check - Importance: Error\n  PASSING - Http Check - Type: HTTP check - Importance: Critical\n  PASSING - Jenkins Check - Type: Jenkins check - Importance: Error\n\n\n', subject='failing status for service: Service', recipient_list=[u'test@userprofile.co.uk'], from_email='Cabot <cabot@example.com>')
-        
+        fake_send_mail.assert_called_with(
+            message=u'Service Service http://localhost/service/1/ alerting with status: failing.\n\nCHECKS FAILING:\n\nPassing checks:\n  PASSING - Graphite Check - Type: Metric check - Importance: Error\n  PASSING - Http Check - Type: HTTP check - Importance: Critical\n  PASSING - Jenkins Check - Type: Jenkins check - Importance: Error\n\n\n',
+            subject='failing status for service: Service',
+            recipient_list=[u'test@userprofile.co.uk'],
+            from_email='Cabot <cabot@example.com>'
+        )

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,13 @@
 [metadata]
 description-file = README.md
+
+[isort]
+known_first_party = cabot
+multi_line_output = 5
+known_django = django
+sections = FUTURE,STDLIB,THIRDPARTY,DJANGO,FIRSTPARTY,LOCALFOLDER
+skip_glob =	**/migrations/*
+
+[flake8]
+exclude = .venv,venv,.tox,dist,doc,build,*.egg,docs,setup.py,*/migrations/
+ignore = E501

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 setup(name='cabot-alert-email',
       version='1.4.3',


### PR DESCRIPTION
The `send_alert` method takes as parameters:
- `users` - the users subscribed to the service
- `duty_officers` - the users on call rota.

From there, it is supposed to add both to the recipients list.
However, in 2d499fd was introduced a bug the service users would
be added twice, and the duty officers would not be added.

Also reformat code and fix all linting violations.